### PR TITLE
pyside wheels for cinema4d 2023.2

### DIFF
--- a/PySide2-Cinema4D-2023.2/PySide2-5.15.2.1-5.15.2-cp310-cp310-win_amd64.whl
+++ b/PySide2-Cinema4D-2023.2/PySide2-5.15.2.1-5.15.2-cp310-cp310-win_amd64.whl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5ccae792128d01ec54c1cab9a9b76eb52bddedaaa4b3e4001e191c828a80c57
+size 123729896

--- a/PySide2-Cinema4D-2023.2/README.md
+++ b/PySide2-Cinema4D-2023.2/README.md
@@ -1,0 +1,9 @@
+# Supported Cinema4D Versions
+
+- 2023.2  
+
+# Build Environment
+
+- Microsoft Visual Studio 2019 [MSC v.1929 64 bit (AMD64)]
+- Python 3.10.10
+- Qt 5.15.2

--- a/PySide2-Cinema4D-2023.2/shiboken2-5.15.2.1-5.15.2-cp310-cp310-win_amd64.whl
+++ b/PySide2-Cinema4D-2023.2/shiboken2-5.15.2.1-5.15.2-cp310-cp310-win_amd64.whl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc31aca5b7b4591c38a67d188b9398dc33b6c10c757b396098957eb7db9de53c
+size 954167


### PR DESCRIPTION
in cinema4d 2023.2 python was updated to 3.10, so here are new wheel